### PR TITLE
fix: removing test console.log

### DIFF
--- a/packages/plugin-coingecko/src/actions/getTrending.ts
+++ b/packages/plugin-coingecko/src/actions/getTrending.ts
@@ -87,7 +87,6 @@ export default {
         callback?: HandlerCallback
     ): Promise<boolean> => {
         elizaLogger.log("Starting CoinGecko GET_TRENDING handler...");
-        console.log("AP STATE: ", { ...state }, "END OF STATE");
 
         if (!state) {
             state = (await runtime.composeState(message)) as State;


### PR DESCRIPTION
There was a console.log where it logged the state before handling the GET_TRENDING action.

This does not have to exist in prod. It was used to debug in dev.

There is a lot in the state being logged and makes the prod logs noisy and difficult to debug.
